### PR TITLE
merge with v4.12.0 and revert buffer redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ is the list of them in the order of appearance in the function name:
 
 ### Postfixes
 
-* `n` - the argument of the function must be a plain JavaScript
+The only available postfix at the moment is:
+
+* `n` - which means that the argument of the function must be a plain JavaScript
   Number. Decimals are not supported.
-* `rn` - both argument and return value of the function are plain JavaScript
-  Numbers. Decimals are not supported.
 
 ### Examples
 
@@ -191,11 +191,6 @@ counterparts in red context:
 * `a.redInvm()` - modular inverse of the number
 * `a.redNeg()`
 * `a.redPow(b)` - modular exponentiation
-
-### Number Size
-
-Optimized for elliptic curves that work with 256-bit numbers.
-There is no limitation on the size of the numbers.
 
 ## LICENSE
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -103,7 +103,7 @@
       this.negative = 1;
     }
 
-    this._strip();
+    this.strip();
 
     if (endian !== 'le') return;
 
@@ -180,38 +180,30 @@
         }
       }
     }
-    return this._strip();
+    return this.strip();
   };
 
   function parseHex (str, start, end) {
     var r = 0;
     var len = Math.min(str.length, end);
-    var z = 0;
     for (var i = start; i < len; i++) {
       var c = str.charCodeAt(i) - 48;
 
       r <<= 4;
 
-      var b;
-
       // 'a' - 'f'
       if (c >= 49 && c <= 54) {
-        b = c - 49 + 0xa;
+        r |= c - 49 + 0xa;
 
       // 'A' - 'F'
       } else if (c >= 17 && c <= 22) {
-        b = c - 17 + 0xa;
+        r |= c - 17 + 0xa;
 
       // '0' - '9'
       } else {
-        b = c;
+        r |= c & 0xf;
       }
-
-      r |= b;
-      z |= b;
     }
-
-    assert(!(z & 0xf0), 'Invalid character in ' + str);
     return r;
   }
 
@@ -242,12 +234,11 @@
       this.words[j] |= (w << off) & 0x3ffffff;
       this.words[j + 1] |= w >>> (26 - off) & 0x3fffff;
     }
-    this._strip();
+    this.strip();
   };
 
   function parseBase (str, start, end, mul) {
     var r = 0;
-    var b = 0;
     var len = Math.min(str.length, end);
     for (var i = start; i < len; i++) {
       var c = str.charCodeAt(i) - 48;
@@ -256,18 +247,16 @@
 
       // 'a'
       if (c >= 49) {
-        b = c - 49 + 0xa;
+        r += c - 49 + 0xa;
 
       // 'A'
       } else if (c >= 17) {
-        b = c - 17 + 0xa;
+        r += c - 17 + 0xa;
 
       // '0' - '9'
       } else {
-        b = c;
+        r += c;
       }
-      assert(c >= 0 && b < mul, 'Invalid character');
-      r += b;
     }
     return r;
   }
@@ -327,13 +316,6 @@
     dest.red = this.red;
   };
 
-  BN.prototype._move = function _move (dest) {
-    dest.words = this.words;
-    dest.length = this.length;
-    dest.negative = this.negative;
-    dest.red = this.red;
-  };
-
   BN.prototype.clone = function clone () {
     var r = new BN(null);
     this.copy(r);
@@ -348,7 +330,7 @@
   };
 
   // Remove leading `0` from `this`
-  BN.prototype._strip = function strip () {
+  BN.prototype.strip = function strip () {
     while (this.length > 1 && this.words[this.length - 1] === 0) {
       this.length--;
     }
@@ -489,7 +471,7 @@
       var c = this.clone();
       c.negative = 0;
       while (!c.isZero()) {
-        var r = c.modrn(groupBase).toString(base);
+        var r = c.modn(groupBase).toString(base);
         c = c.idivn(groupBase);
 
         if (!c.isZero()) {
@@ -527,14 +509,13 @@
   };
 
   BN.prototype.toJSON = function toJSON () {
-    return this.toString(16, 2);
+    return this.toString(16);
   };
 
-  if (Buffer) {
-    BN.prototype.toBuffer = function toBuffer (endian, length) {
-      return this.toArrayLike(Buffer, endian, length);
-    };
-  }
+  BN.prototype.toBuffer = function toBuffer (endian, length) {
+    assert(typeof Buffer !== 'undefined');
+    return this.toArrayLike(Buffer, endian, length);
+  };
 
   BN.prototype.toArray = function toArray (endian, length) {
     return this.toArrayLike(Array, endian, length);
@@ -546,9 +527,9 @@
     assert(byteLength <= reqLength, 'byte array longer than desired length');
     assert(reqLength > 0, 'Requested array length <= 0');
 
-    this._strip();
+    this.strip();
     var littleEndian = endian === 'le';
-    var res = allocate(ArrayType, reqLength);
+    var res = new ArrayType(reqLength);
 
     var b, i;
     var q = this.clone();
@@ -578,13 +559,6 @@
     }
 
     return res;
-  };
-
-  var allocate = function allocate (ArrayType, size) {
-    if (ArrayType.allocUnsafe) {
-      return ArrayType.allocUnsafe(size);
-    }
-    return new ArrayType(size);
   };
 
   if (Math.clz32) {
@@ -721,7 +695,7 @@
       this.words[i] = this.words[i] | num.words[i];
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.ior = function ior (num) {
@@ -756,7 +730,7 @@
 
     this.length = b.length;
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.iand = function iand (num) {
@@ -800,7 +774,7 @@
 
     this.length = a.length;
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.ixor = function ixor (num) {
@@ -844,7 +818,7 @@
     }
 
     // And remove leading zeroes
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.notn = function notn (width) {
@@ -866,7 +840,7 @@
       this.words[off] = this.words[off] & ~(1 << wbit);
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   // Add `num` to `this` in-place
@@ -1007,7 +981,7 @@
       this.negative = 1;
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   // Subtract `num` from `this`
@@ -1053,7 +1027,7 @@
       out.length--;
     }
 
-    return out._strip();
+    return out.strip();
   }
 
   // TODO(indutny): it may be reasonable to omit it for users who don't need
@@ -1675,7 +1649,7 @@
       out.length--;
     }
 
-    return out._strip();
+    return out.strip();
   }
 
   function jumboMulTo (self, num, out) {
@@ -1892,7 +1866,7 @@
 
     out.negative = x.negative ^ y.negative;
     out.length = x.length + y.length;
-    return out._strip();
+    return out.strip();
   };
 
   // Multiply `this` by `num`
@@ -1915,9 +1889,6 @@
   };
 
   BN.prototype.imuln = function imuln (num) {
-    var isNegNum = num < 0;
-    if (isNegNum) num = -num;
-
     assert(typeof num === 'number');
     assert(num < 0x4000000);
 
@@ -1938,7 +1909,7 @@
       this.length++;
     }
 
-    return isNegNum ? this.ineg() : this;
+    return this;
   };
 
   BN.prototype.muln = function muln (num) {
@@ -2013,7 +1984,7 @@
       this.length += s;
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.ishln = function ishln (bits) {
@@ -2079,7 +2050,7 @@
       this.length = 1;
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.ishrn = function ishrn (bits, hint, extended) {
@@ -2144,7 +2115,7 @@
       this.words[this.length - 1] &= mask;
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   // Return only lowers bits of number
@@ -2219,7 +2190,7 @@
       }
     }
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype.addn = function addn (num) {
@@ -2261,7 +2232,7 @@
       this.words[i + shift] = w & 0x3ffffff;
     }
 
-    if (carry === 0) return this._strip();
+    if (carry === 0) return this.strip();
 
     // Subtraction overflow
     assert(carry === -1);
@@ -2273,7 +2244,7 @@
     }
     this.negative = 1;
 
-    return this._strip();
+    return this.strip();
   };
 
   BN.prototype._wordDiv = function _wordDiv (num, mode) {
@@ -2335,9 +2306,9 @@
       }
     }
     if (q) {
-      q._strip();
+      q.strip();
     }
-    a._strip();
+    a.strip();
 
     // Denormalize
     if (mode !== 'div' && shift !== 0) {
@@ -2436,13 +2407,13 @@
       if (mode === 'mod') {
         return {
           div: null,
-          mod: new BN(this.modrn(num.words[0]))
+          mod: new BN(this.modn(num.words[0]))
         };
       }
 
       return {
         div: this.divn(num.words[0]),
-        mod: new BN(this.modrn(num.words[0]))
+        mod: new BN(this.modn(num.words[0]))
       };
     }
 
@@ -2483,10 +2454,7 @@
     return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
   };
 
-  BN.prototype.modrn = function modrn (num) {
-    var isNegNum = num < 0;
-    if (isNegNum) num = -num;
-
+  BN.prototype.modn = function modn (num) {
     assert(num <= 0x3ffffff);
     var p = (1 << 26) % num;
 
@@ -2495,19 +2463,11 @@
       acc = (p * acc + (this.words[i] | 0)) % num;
     }
 
-    return isNegNum ? -acc : acc;
-  };
-
-  // WARNING: DEPRECATED
-  BN.prototype.modn = function modn (num) {
-    return this.modrn(num);
+    return acc;
   };
 
   // In-place division by number
   BN.prototype.idivn = function idivn (num) {
-    var isNegNum = num < 0;
-    if (isNegNum) num = -num;
-
     assert(num <= 0x3ffffff);
 
     var carry = 0;
@@ -2517,8 +2477,7 @@
       carry = w % num;
     }
 
-    this._strip();
-    return isNegNum ? this.ineg() : this;
+    return this.strip();
   };
 
   BN.prototype.divn = function divn (num) {
@@ -2770,7 +2729,7 @@
     if (this.negative !== 0 && !negative) return -1;
     if (this.negative === 0 && negative) return 1;
 
-    this._strip();
+    this.strip();
 
     var res;
     if (this.length > 1) {
@@ -3013,7 +2972,7 @@
     } else if (cmp > 0) {
       r.isub(this.p);
     } else {
-      r._strip();
+      r.strip();
     }
 
     return r;
@@ -3186,9 +3145,7 @@
 
   Red.prototype.imod = function imod (a) {
     if (this.prime) return this.prime.ireduce(a)._forceRed(this);
-
-    a.umod(this.m)._forceRed(this)._move(a);
-    return a;
+    return a.umod(this.m)._forceRed(this);
   };
 
   Red.prototype.neg = function neg (a) {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,7 @@
   "bugs": {
     "url": "https://github.com/indutny/bn.js/issues"
   },
-  "files": [
-    "lib"
-  ],
   "homepage": "https://github.com/indutny/bn.js",
-  "browser": {
-    "buffer": "./node_modules/buffer/index.js"
-  },
   "dependencies": {
     "buffer": "5.2.0"
   },


### PR DESCRIPTION
As I see, v4.12.0 fix some bugs, and add
```js
"browser": {	
    "buffer": "./node_modules/buffer/index.js"	
  },
```
to support `Buffer` in browser.

But it seems should be added in main `package.json` that use this repo.